### PR TITLE
changes to state vars reducing rerenders

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "react-avatar": "^3.9.7",
-    "react-sizeme": "^2.6.12"
+    "react-sizeme": "^3.0.2"
   },
   "peerDependencies": {
     "react": "17.x"
@@ -29,8 +29,8 @@
   "devDependencies": {
     "inferno": "^5.6.1",
     "nwb": "^0.25.2",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   },
   "author": "Michael Odling-Smee",
   "homepage": "airelogic.com",

--- a/src/AreaArcSVG.js
+++ b/src/AreaArcSVG.js
@@ -3,18 +3,20 @@ import AreaTeamArcSVG from './AreaTeamArcSVG';
 import AreaLeadArcSVG from './AreaLeadArcSVG';
 import PropTypes from 'prop-types';
 import './AreaArcSVG.css';
+import { PortfolioContext } from './PortfolioContext';
 
 export class AreaArcSVG extends Component {
 
     constructor(props) {
         super(props);
-        this.state = {
-            tooltip: false,
-            currentPortfolioItem: {},
-        };
         this.showAreaDetails = this.showAreaDetails.bind(this);
         this.hideAreaDetails = this.hideAreaDetails.bind(this);
         this.areaOnClick = this.areaOnClick.bind(this);
+    }
+
+    shouldComponentUpdate(nextProps) {
+        //Update the SVG only if the associated portfolio item has changed
+        return (this.props.portfolioItem !== nextProps.portfolioItem);
     }
 
     showAreaDetails = () => {
@@ -47,20 +49,26 @@ export class AreaArcSVG extends Component {
         const textLocalRot = flipText ? "rotate(180, " + textXPos + ",0)": "";
         const textAnchor = flipText ? "end" : "start";
         return (
-            <g className="portfolioArea" {...passThroughProps} onClick={this.areaOnClick} onMouseEnter={this.showAreaDetails} onMouseLeave={this.hideAreaDetails}>
-                <animateTransform className="rot" attributeName="transform" attributeType="XML" type="rotate" to={rot} dur="1s" begin="0s" repeatCount="1" fill="freeze" restart="always"/>
-                <animateTransform attributeName="transform" attributeType="XML" type="scale" dur="2s" keyTimes="0.0; 0.25; 0.8; 1.0" values="1.0; 1.1; 1.03; 1.0" begin="mouseover" additive="sum" restart="whenNotActive"/>
-                <AreaTeamArcSVG r={r2} strokeWidth={strokeWidth} {...passThroughProps} portfolioTheme={portfolioTheme}/>
-                <AreaLeadArcSVG r={r1} {...passThroughProps} portfolioTheme={portfolioTheme}/>
-                <g transform={textRotTx}>
-                    <text alignmentBaseline="middle" x={r1*1.3} y="0" textAnchor={textAnchor} fill="black" fontSize="8" transform={textLocalRot}>{this.props.portfolioItem.title}</text>  
-                </g>
-                {/* 
-                    TODO fix these hardcoded values. 
-                    This opaque arc is needed to prevent mouseover jitter 
-                */}
-                <AreaTeamArcSVG r={140} strokeWidth={200} {...passThroughProps} opacity={0} portfolioTheme={portfolioTheme}/>
-            </g>
+            <React.Fragment>
+                <PortfolioContext.Consumer>
+                    {(context) => (
+                        <g className="portfolioArea" {...passThroughProps} onClick={this.areaOnClick} onMouseEnter={this.showAreaDetails} onMouseLeave={this.hideAreaDetails} onMouseMove={context.onHoverMove}>
+                            <animateTransform className="rot" attributeName="transform" attributeType="XML" type="rotate" to={rot} dur="1s" begin="0s" repeatCount="1" fill="freeze" restart="always"/>
+                            <animateTransform attributeName="transform" attributeType="XML" type="scale" dur="2s" keyTimes="0.0; 0.25; 0.8; 1.0" values="1.0; 1.1; 1.03; 1.0" begin="mouseover" additive="sum" restart="whenNotActive"/>
+                            <AreaTeamArcSVG r={r2} strokeWidth={strokeWidth} {...passThroughProps} portfolioTheme={portfolioTheme}/>
+                            <AreaLeadArcSVG r={r1} {...passThroughProps} portfolioTheme={portfolioTheme}/>
+                            <g transform={textRotTx}>
+                                <text alignmentBaseline="middle" x={r1*1.3} y="0" textAnchor={textAnchor} fill="black" fontSize="8" transform={textLocalRot}>{this.props.portfolioItem.title}</text>  
+                            </g>
+                            {/* 
+                                TODO fix these hardcoded values. 
+                                This opaque arc is needed to prevent mouseover jitter 
+                            */}
+                            <AreaTeamArcSVG r={140} strokeWidth={200} {...passThroughProps} opacity={0} portfolioTheme={portfolioTheme}/>
+                        </g>
+                    )}
+                </PortfolioContext.Consumer>
+            </React.Fragment>
         );
     }
 }

--- a/src/PortfolioContext.js
+++ b/src/PortfolioContext.js
@@ -1,0 +1,26 @@
+import React, { Component } from 'react';
+
+
+export const PortfolioContext = React.createContext();
+
+export class PortfolioProvider extends Component {
+  state = {
+    x : 0,
+    y: 0
+  }
+
+  render() {
+    return (
+      <PortfolioContext.Provider value={
+        {
+          state: this.state,
+          onHoverMove: (e) => {
+              this.setState({ x: e.pageX, y: e.pageY});
+          }          
+        }
+      }>
+      {this.props.children}
+      </PortfolioContext.Provider>
+    )
+  }
+}

--- a/src/PortfolioExplorer.js
+++ b/src/PortfolioExplorer.js
@@ -7,6 +7,7 @@ import ToolTipOverlay from './TootipOverlay';
 import './PortfolioExplorer.css';
 import PortfolioExplorerGuides from './PortfolioExplorerGuides';
 import PortfolioOversight from './PortfolioOversight';
+import { PortfolioProvider } from './PortfolioContext';
 
 export class PortfolioExplorer extends Component {
 
@@ -14,30 +15,29 @@ export class PortfolioExplorer extends Component {
         super(props);
         this.state = {
             show: false,
-            toolTipX: 0,
-            toolTipY: 0,
             currentPortfolioItem: {},
+            previousPortfolio: {},
+            areas: [],
+            areasSVG: [],
+            groupsSVG: [],
+            itemScaleMax: -1,
         };
         this.onShowToolTip = this.onShowToolTip.bind(this);
         this.onHideToolTip = this.onHideToolTip.bind(this);
-        this.onHoverMove = this.onHoverMove.bind(this);
     }
 
     onShowToolTip = (toolTipInfo) => {
-        this.setState({ show: true });
-        this.setState({toolTipInfo: toolTipInfo});
-    };
-
-    onHoverMove = (e) => {  
-        if (this.state.show) {     
-            this.setState({ toolTipX: e.pageX});
-            this.setState({ toolTipY: e.pageY});
-        }
+        this.setState({ 
+            show: true,
+            toolTipInfo: toolTipInfo 
+        });
     };
 
     onHideToolTip = () => {
-        this.setState({ show: false });
-        this.setState({ currentPortfolioItem: {} });
+        this.setState({
+             show: false,
+             currentPortfolioItem: {}
+            });
     };
 
     componentDidUpdate(prevProps) {
@@ -46,11 +46,13 @@ export class PortfolioExplorer extends Component {
             document.querySelectorAll("animateTransform").forEach(
                 element => {
                     if (element.getAttribute("type") === "rotate") {
-                        element.beginElement(); 
+                        element.beginElement();
                     }
                 }
             );
         }
+
+        this.state.previousPortfolio = this.props.portfolio;
     }
 
     render() {
@@ -59,53 +61,61 @@ export class PortfolioExplorer extends Component {
 
         let title = this.props.title;
         let portfolio = this.props.portfolio;
-        
-        // Initialise portfolio Objects
-        var areas = [];
-        // Get all the areas from the portfolio groups
-        portfolio.portfolioGroups.forEach(portfolioGroup => { 
-            areas = [].concat(areas, portfolioGroup.areas);
-        }); 
-        
-        // Get the max scale of all items
-        const itemCount = areas.length;
-        const spacing = itemCount > 1 ? 2 * itemCount : 0;
-        const fullProjDeg = 360 / itemCount;
-        const projDeg = (360 - spacing) / itemCount;
-        
 
-        // Get the max sized project
-        var itemScaleMax = -1;
-        areas.forEach(portfolioItem => { 
-            itemScaleMax = portfolioItem.scale-1 > itemScaleMax ? portfolioItem.scale-1 : itemScaleMax;
-        });
-        var areasSVG = [];
-        var groupsSVG = [];
-        areas.forEach((portfolioItem, index) => {
-            let strokeWidth = strokeWidthMax * ((portfolioItem.scale - 1) / itemScaleMax);
-            let r2 = r1 + strokeWidth / 2;
-            let pRot = index * fullProjDeg * -1;
-            areasSVG.push(<AreaArcSVG portfolioTheme={this.props.portfolioTheme} areaonclick={this.props.areaonclick} showToolTip={this.onShowToolTip} hideToolTip={this.onHideToolTip} onMouseMove={this.onHoverMove} portfolioItem={portfolioItem} key={index} r1={r1} r2={r2} deg={projDeg} rot={pRot} strokeWidth={strokeWidth}/>);
-        });
-        var rotInitial = 0;
-        portfolio.portfolioGroups.forEach((portfolioGroup, index) => { 
-            var groupAreaCount = portfolioGroup.areas.length;
-            var spacing = portfolio.portfolioGroups.length > 1 ? 3 : 0;
-            var deg = (fullProjDeg * groupAreaCount) - spacing;
-            groupsSVG.push(<PortfolioGroupArcSVG portfolioTheme={this.props.portfolioTheme} portfoliogrouponclick={this.props.portfoliogrouponclick} r={40} deg={deg} rot={rotInitial} key={index}  showToolTip={this.onShowToolTip} hideToolTip={this.onHideToolTip} onMouseMove={this.onHoverMove} portfolioGroup={portfolioGroup}/>);
-            rotInitial -= (fullProjDeg * groupAreaCount);
-        }); 
+        if (this.state.previousPortfolio !== portfolio) {
+            this.state.areas = [];
+            portfolio.portfolioGroups.forEach(portfolioGroup => {
+                this.state.areas = [].concat(this.state.areas, portfolioGroup.areas);
+            });
+
+            var itemScaleMax = -1;
+            this.state.areas.forEach(portfolioItem => {
+                this.state.itemScaleMax = portfolioItem.scale - 1 > itemScaleMax ? portfolioItem.scale - 1 : itemScaleMax;
+            });
+
+             // Get the max scale of all items
+            const itemCount = this.state.areas.length;
+            const spacing = itemCount > 1 ? 2 * itemCount : 0;
+            const fullProjDeg = 360 / itemCount;
+            const projDeg = (360 - spacing) / itemCount;
+
+            // Get the max sized project
+            this.state.areas.forEach(portfolioItem => { 
+                this.state.itemScaleMax = portfolioItem.scale-1 > this.state.itemScaleMax ? portfolioItem.scale-1 : this.state.itemScaleMax;
+            });
+
+            this.state.areasSVG = [];
+            this.state.groupsSVG = [];
+
+            this.state.areas.forEach((portfolioItem, index) => {
+                let strokeWidth = strokeWidthMax * ((portfolioItem.scale - 1) / itemScaleMax);
+                let r2 = r1 + strokeWidth / 2;
+                let pRot = index * fullProjDeg * -1;
+                this.state.areasSVG.push(<AreaArcSVG portfolioTheme={this.props.portfolioTheme} areaonclick={this.props.areaonclick} showToolTip={this.onShowToolTip} hideToolTip={this.onHideToolTip} portfolioItem={portfolioItem} key={index} r1={r1} r2={r2} deg={projDeg} rot={pRot} strokeWidth={strokeWidth}/>);
+            });
+            var rotInitial = 0;
+            portfolio.portfolioGroups.forEach((portfolioGroup, index) => { 
+                var groupAreaCount = portfolioGroup.areas.length;
+                var spacing = portfolio.portfolioGroups.length > 1 ? 3 : 0;
+                var deg = (fullProjDeg * groupAreaCount) - spacing;
+                this.state.groupsSVG.push(<PortfolioGroupArcSVG portfolioTheme={this.props.portfolioTheme} portfoliogrouponclick={this.props.portfoliogrouponclick} r={40} deg={deg} rot={rotInitial} key={index}  showToolTip={this.onShowToolTip} hideToolTip={this.onHideToolTip} portfolioGroup={portfolioGroup}/>);
+                rotInitial -= (fullProjDeg * groupAreaCount);
+            }); 
+        }
+
         return (
             <React.Fragment>
                 <div className="portfolioExplorer">
                     <h2>{title}</h2>
-                    <ToolTipOverlay visible={this.state.show} x={this.state.toolTipX} y={this.state.toolTipY} tooltipInfo={this.state.toolTipInfo}/>
-                    <svg viewBox="-250 -250 500 500" preserveAspectRatio="xMinYMin meet">
-                        <PortfolioExplorerGuides visible={false}/>
-                        <PortfolioOversight portfolioTheme={this.props.portfolioTheme} portfolioOversight={portfolio.portFolioManagementTeam} showToolTip={this.onShowToolTip} hideToolTip={this.onHideToolTip} onMouseMove={this.onHoverMove} portfoliooversightonclick={this.props.portfoliooversightonclick}/>                        
-                        {areasSVG}
-                        {groupsSVG}                                                        
-                    </svg>
+                    <PortfolioProvider>
+                        <ToolTipOverlay visible={this.state.show} tooltipInfo={this.state.toolTipInfo} />
+                        <svg viewBox="-250 -250 500 500" preserveAspectRatio="xMinYMin meet">
+                            <PortfolioExplorerGuides visible={false} />
+                            <PortfolioOversight portfolioTheme={this.props.portfolioTheme} portfolioOversight={portfolio.portFolioManagementTeam} showToolTip={this.onShowToolTip} hideToolTip={this.onHideToolTip} portfoliooversightonclick={this.props.portfoliooversightonclick} />
+                            {this.state.areasSVG}
+                            {this.state.groupsSVG}
+                        </svg>
+                    </PortfolioProvider>
                 </div>
             </React.Fragment>
         );

--- a/src/PortfolioGroupArcSVG.js
+++ b/src/PortfolioGroupArcSVG.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import asSVGArc from './GenericArcSVG';
 import './PortfolioGroupArcSVG.css';
+import { PortfolioContext } from './PortfolioContext';
 
 export class PortfolioGroupArcSVG extends Component {
 
@@ -28,18 +29,28 @@ export class PortfolioGroupArcSVG extends Component {
         this.props.portfoliogrouponclick ? this.props.portfoliogrouponclick(this.props.portfolioGroup.groupTitle) : undefined;
     };
 
+    shouldComponentUpdate(nextProps) {
+        //Update the SVG only if the associated portfolio item has changed
+        return (this.props.portfolioGroup !== nextProps.portfolioGroup);
+    }
+
     render() {
         const {portfolioTheme, portfolioGroup, showToolTip, hideToolTip, portfoliogrouponclick, ...passThroughProps} = this.props;
         return (
-            
-            <g className="oversightArc" onClick={this.portfolioGroupOnClick} onMouseEnter={this.showAreaDetails} onMouseLeave={this.hideAreaDetails}>
-                <animateTransform attributeName="transform" attributeType="XML" type="scale" dur="2s" keyTimes="0.0; 0.25; 0.8; 1.0" values="1.0; 1.03; 1.02; 1.0" begin="mouseover" additive="sum" restart="whenNotActive" />
+            <React.Fragment>
+            <PortfolioContext.Consumer>
+                {(context) => (
+                    <g className="oversightArc" onClick={this.portfolioGroupOnClick} onMouseEnter={this.showAreaDetails} onMouseLeave={this.hideAreaDetails} onMouseMove={context.onHoverMove}>
+                        <animateTransform attributeName="transform" attributeType="XML" type="scale" dur="2s" keyTimes="0.0; 0.25; 0.8; 1.0" values="1.0; 1.03; 1.02; 1.0" begin="mouseover" additive="sum" restart="whenNotActive" />
 
-                <path {...passThroughProps}
-                    fill="none"
-                    stroke={portfolioTheme.area}
-                    strokeWidth="15" />
-            </g>
+                        <path {...passThroughProps}
+                            fill="none"
+                            stroke={portfolioTheme.area}
+                            strokeWidth="15" />
+                    </g>
+                )}
+                </PortfolioContext.Consumer>
+            </React.Fragment>
         );
     }
 }

--- a/src/PortfolioOversight.js
+++ b/src/PortfolioOversight.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import OversightCircle from './OversightCircle';
+import { PortfolioContext } from './PortfolioContext';
 
 export class PortfolioOversight extends Component {
 
@@ -33,12 +34,18 @@ export class PortfolioOversight extends Component {
     render() {
         const {portfolioOversight, portfoliooversightonclick, showToolTip, hideToolTip, portfolioTheme, ...passThroughProps} = this.props;
         return (
-            <g {...passThroughProps} className="portfolioOversight" onClick={this.onClick} onMouseEnter={this.showPortfolioOversightDetails} onMouseLeave={this.hidePortfolioOversightDetails}>
-                <g transform="translate(-15 -15)">
-                    <image height="30" width="30" xlinkHref={portfolioTheme.logo}/>
-                </g>
-                <OversightCircle cx={0} cy={0} r={25}/>
-            </g>
+            <React.Fragment>
+            <PortfolioContext.Consumer>
+                {(context) => (
+                    <g {...passThroughProps} className="portfolioOversight" onClick={this.onClick} onMouseMove={context.onHoverMove} onMouseEnter={this.showPortfolioOversightDetails} onMouseLeave={this.hidePortfolioOversightDetails}>
+                        <g transform="translate(-15 -15)">
+                            <image height="30" width="30" xlinkHref={portfolioTheme.logo}/>
+                        </g>
+                        <OversightCircle cx={0} cy={0} r={25}/>
+                    </g>
+                )}
+                </PortfolioContext.Consumer>
+            </React.Fragment>
         );
     }
 }

--- a/src/TootipOverlay.js
+++ b/src/TootipOverlay.js
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
 import { withSize } from 'react-sizeme';
 import Avatar from 'react-avatar';
-
 import './ToolTipOverlay.css';
+import { PortfolioContext } from './PortfolioContext';
 
 export class ToolTipOverlay extends Component {
+
+    static contextType = PortfolioContext;
 
     render() {
         var cursorDistance = 20;
@@ -14,8 +16,8 @@ export class ToolTipOverlay extends Component {
         var pageHeight = window.innerHeight;
         var pageWidth = window.innerWidth;
         
-        var xOffset = this.props.x < 0.6 * pageWidth ? cursorDistance : -1 * (width + cursorDistance);
-        var yOffset = this.props.y < 0.6 * pageHeight ? cursorDistance : -1 * (height + cursorDistance);
+        var xOffset = this.context.state.x < 0.6 * pageWidth ? cursorDistance : -1 * (width + cursorDistance);
+        var yOffset = this.context.state.y < 0.6 * pageHeight ? cursorDistance : -1 * (height + cursorDistance);
         var teamAvatars = [];
         var responsiblePersons = [];
         if (this.props.tooltipInfo && this.props.tooltipInfo.responsiblePerson) {
@@ -37,23 +39,21 @@ export class ToolTipOverlay extends Component {
         return (
             <React.Fragment>
                 {visible &&
-
-                    <div id="tooltip" style={{left: `${this.props.x + xOffset}px`, top: `${this.props.y + yOffset}px`}}>
-                        <h2>{this.props.tooltipInfo.title}</h2>
-                        {this.props.tooltipInfo.customer &&
-                            <div className="subtle italic">{this.props.tooltipInfo.customer}</div>
-                        }
-                        <p>{this.props.tooltipInfo.description}</p>
-                        {hasTeamMembers &&
-                            <div className="team">
-                                {responsiblePerson &&
-                                    <div className="responsiblePersons">{responsiblePersons}</div>
+                            <div id="tooltip" style={{left: `${this.context.state.x + xOffset}px`, top: `${this.context.state.y + yOffset}px`}}>
+                                <h2>{this.props.tooltipInfo.title}</h2>
+                                {this.props.tooltipInfo.customer &&
+                                    <div className="subtle italic">{this.props.tooltipInfo.customer}</div>
                                 }
-                                <div className="teamMembers">{teamAvatars}</div>
-                            </div>               
-                        }   
-                            
-                    </div>
+                                <p>{this.props.tooltipInfo.description}</p>
+                                {hasTeamMembers &&
+                                    <div className="team">
+                                        {responsiblePerson &&
+                                            <div className="responsiblePersons">{responsiblePersons}</div>
+                                        }
+                                        <div className="teamMembers">{teamAvatars}</div>
+                                    </div>               
+                                }                                   
+                        </div>
                 }
             </React.Fragment>
         );


### PR DESCRIPTION
- Updates react-sizeme to the latest version so that it is compatible with react 17
- Stores SVG components in state to avoid rerendering and recalculating them when associated data has not changed
- mouse movement state is now held in context and only triggers rerendering of the tooltip component, rather than all components