### PR TITLE
Tooltip Overlay supports basic formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airelogic/portfolio-explorer",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Portfolio Explorer React component",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/SanitizedHTML.tsx
+++ b/src/SanitizedHTML.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import sanitizeHTML from 'xss';
+
+interface Props
+  extends Omit<
+    React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>,
+    'dangerouslySetInnerHTML'
+  > {
+  html?: string;
+}
+
+const SanitizedHTML: React.FC<Props> = ({ html, ...rest }) => {
+  const sanitizedHTML = html
+    ? sanitizeHTML(html, {
+        whiteList: {
+          h1: [],
+          h2: [],
+          h3: [],
+          p: [],
+          ol: [],
+          li: [],
+          ul: [],
+          u: [],
+          em: [],
+          br: [],
+          b: [],
+          i: [],
+          small: [],
+          strong: [],
+          sub: [],
+          sup: [],
+        },
+      })
+    : '';
+
+  return <span {...rest} dangerouslySetInnerHTML={{ __html: sanitizedHTML }} />;
+};
+
+export default SanitizedHTML;

--- a/src/TootipOverlay.tsx
+++ b/src/TootipOverlay.tsx
@@ -3,6 +3,7 @@ import Avatar from "react-avatar";
 import "./ToolTipOverlay.css";
 import { PortfolioArea } from "./types";
 import { Portal } from 'react-portal';
+import SanitizedHTML from "./SanitizedHTML";
 
 interface ToolTipOverlayProps {
   item: Pick<
@@ -92,7 +93,7 @@ const ToolTipOverlay: React.FC<ToolTipOverlayProps> = (props) => {
       {props.item.customer && (
         <div className="subtle italic">{props.item.customer}</div>
       )}
-      <p>{props.item.description}</p>
+      <SanitizedHTML html={props.item.description}/>
       {hasTeamMembers && (
         <div className="team">
           {responsiblePerson && (


### PR DESCRIPTION
Allow formatted strings in tool tip item description. Injected HTML is sanitized with a  basic whitelist of supported elements.