### PR TITLE
add props to hide/show teamMembers. default is to hide

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airelogic/portfolio-explorer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Portfolio Explorer React component",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/AreaArcSVG.tsx
+++ b/src/AreaArcSVG.tsx
@@ -8,9 +8,10 @@ interface PortfolioGroupArcSVGProps extends SVGProps<SVGGElement> {
   portfoliogrouponclick?: (group: PortfolioGroup) => void;
   portfolioGroup: PortfolioGroup;
   portfolioTheme: PortfolioTheme;
+  showTeamMembers?: boolean;
 }
 
-export const AreaArcSVG: React.FC<PortfolioGroupArcSVGProps> = ({ portfoliogrouponclick, portfolioGroup, portfolioTheme, ...svgProps }) => {
+export const AreaArcSVG: React.FC<PortfolioGroupArcSVGProps> = ({ showTeamMembers, portfoliogrouponclick, portfolioGroup, portfolioTheme, ...svgProps }) => {
   const [showTooltip, setShowTooltip] = useState(false);
 
   const portfolioGroupOnClick = () => {
@@ -19,7 +20,7 @@ export const AreaArcSVG: React.FC<PortfolioGroupArcSVGProps> = ({ portfoliogroup
 
   return (
     <Fragment>
-      {showTooltip && <ToolTipOverlay item={{ ...portfolioGroup, team: portfolioGroup.groupResponsiblePerson ?? [] }} />}
+      {showTooltip && <ToolTipOverlay item={{ ...portfolioGroup, team: portfolioGroup.groupResponsiblePerson ?? [] }} showTeamMembers={showTeamMembers} />}
       <g
         className="areaArc"
         onClick={portfolioGroupOnClick}

--- a/src/PortfolioExplorer.tsx
+++ b/src/PortfolioExplorer.tsx
@@ -17,6 +17,7 @@ interface PortfolioExplorerProps {
   areaonclick: (area: PortfolioArea) => void;
   portfoliooversightonclick: (areaId: string) => void;
   groupOnClick: (group: PortfolioGroup) => void;
+  showTeamMembers?: boolean;
 }
 
 interface PortfolioExplorerState {
@@ -90,6 +91,7 @@ export class PortfolioExplorer extends Component<
           rot={pRot}
           strokeWidth={strokeWidth}
           theme={this.props.portfolioTheme}
+          showTeamMembers={this.props.showTeamMembers}
         />
       );
     });
@@ -109,6 +111,7 @@ export class PortfolioExplorer extends Component<
           rot={rotInitial}
           key={index}
           portfolioGroup={portfolioGroup}
+          showTeamMembers={this.props.showTeamMembers}
         />
       );
       rotInitial -= fullAreaDeg * projectCount;
@@ -125,6 +128,7 @@ export class PortfolioExplorer extends Component<
                 portfolioTheme={this.props.portfolioTheme}
                 oversight={oversight}
                 portfoliooversightonclick={this.props.portfoliooversightonclick}
+                showTeamMembers={this.props.showTeamMembers}
               />
             )}
             {projectsSVG}

--- a/src/PortfolioOversight.tsx
+++ b/src/PortfolioOversight.tsx
@@ -8,7 +8,8 @@ export const PortfolioOversight: React.FC<{
   portfoliooversightonclick?: (areaId: string) => void;
   portfolioTheme: PortfolioTheme;
   oversight: PortFolioManagementTeamUI;
-}> = ({ portfoliooversightonclick, portfolioTheme, oversight }) => {
+  showTeamMembers?: boolean;
+}> = ({ portfoliooversightonclick, portfolioTheme, oversight, showTeamMembers }) => {
   const [showTooltip, setShowTooltip] = useState(false);
 
   const onClick = () => {
@@ -17,7 +18,7 @@ export const PortfolioOversight: React.FC<{
 
   return (
     <Fragment>
-      {showTooltip && <ToolTipOverlay item={oversight} />}
+      {showTooltip && <ToolTipOverlay item={oversight} showTeamMembers={showTeamMembers} />}
       <g
         className="portfolioOversight"
         onClick={onClick}

--- a/src/ProjectArcSVG.tsx
+++ b/src/ProjectArcSVG.tsx
@@ -15,9 +15,11 @@ interface AreaArcSVGProps extends SVGProps<SVGGElement> {
   r2: number;
   rot: number;
   deg: number;
+  showTeamMembers?: boolean;
 }
 
 export const ProjectArcSVG: React.FC<AreaArcSVGProps> = ({
+  showTeamMembers,
   areaonclick,
   portfolioItem,
   portfolioTheme,
@@ -45,7 +47,7 @@ export const ProjectArcSVG: React.FC<AreaArcSVGProps> = ({
   const passThroughProps = { ...svgProps, deg, strokeWidth };
   return (
     <Fragment>
-      {showTooltip && <ToolTipOverlay item={portfolioItem} />}
+      {showTooltip && <ToolTipOverlay item={portfolioItem} showTeamMembers={showTeamMembers} />}
       <g
         className="project"
         transform={`rotate(${rot*-1},0,0)`}

--- a/src/TootipOverlay.tsx
+++ b/src/TootipOverlay.tsx
@@ -9,7 +9,8 @@ interface ToolTipOverlayProps {
   item: Pick<
     PortfolioArea,
     "responsiblePerson" | "team" | "title" | "customer" | "description"
-  >
+  >,
+  showTeamMembers?: boolean
 }
 
 const useMousePosition = () => {
@@ -31,6 +32,7 @@ const ToolTipOverlay: React.FC<ToolTipOverlayProps> = (props) => {
   const mousePosition = useMousePosition();
   const cursorDistance = 20;
   const responsiblePerson = props.item && props.item.responsiblePerson;
+  const showTeamMembers = props.showTeamMembers?? false;
   const { offsetWidth, offsetHeight } = ref.current ?? { offsetWidth: 0, offsetHeight: 0};
   const pageHeight = window.innerHeight;
   const pageWidth = window.innerWidth;
@@ -94,7 +96,7 @@ const ToolTipOverlay: React.FC<ToolTipOverlayProps> = (props) => {
         <div className="subtle italic">{props.item.customer}</div>
       )}
       <SanitizedHTML html={props.item.description}/>
-      {hasTeamMembers && (
+      {(showTeamMembers && hasTeamMembers) && (
         <div className="team">
           {responsiblePerson && (
             <div className="responsiblePersons">{responsiblePersons}</div>


### PR DESCRIPTION
Work from AC-1358. We don't want to show TeamMembers on the tooltip anymore. hides by default now but functionality is left and can be shown with props